### PR TITLE
Order price can now be 0 to accommodate unusual scenarios 

### DIFF
--- a/vectorbt/portfolio/nb.py
+++ b/vectorbt/portfolio/nb.py
@@ -380,7 +380,7 @@ def execute_order_nb(state: ProcessOrderState, order: Order) -> tp.Tuple[Execute
     if order.direction == Direction.ShortOnly and position > 0:
         raise ValueError("position is positive but order.direction is Direction.ShortOnly")
     if not np.isfinite(order.price) or order.price < 0:
-        raise ValueError("order.price must be finite and greater than 0")
+        raise ValueError("order.price must be finite and greater than or equal to 0")
     if not np.isfinite(order.fees) or order.fees < 0:
         raise ValueError("order.fees must be finite and 0 or greater")
     if not np.isfinite(order.fixed_fees) or order.fixed_fees < 0:

--- a/vectorbt/portfolio/nb.py
+++ b/vectorbt/portfolio/nb.py
@@ -379,7 +379,7 @@ def execute_order_nb(state: ProcessOrderState, order: Order) -> tp.Tuple[Execute
         raise ValueError("position is negative but order.direction is Direction.LongOnly")
     if order.direction == Direction.ShortOnly and position > 0:
         raise ValueError("position is positive but order.direction is Direction.ShortOnly")
-    if not np.isfinite(order.price) or order.price <= 0:
+    if not np.isfinite(order.price) or order.price < 0:
         raise ValueError("order.price must be finite and greater than 0")
     if not np.isfinite(order.fees) or order.fees < 0:
         raise ValueError("order.fees must be finite and 0 or greater")


### PR DESCRIPTION
Eg: Closing a position at 100% loss such as simulating an open position on a stock (price > 0) and then "closing" said position when the stock is delisted (ie stock price is 0)